### PR TITLE
fix: Handle name change from Sequence to Strip in Blender 4.4

### DIFF
--- a/src/ui/implementations_panel.py
+++ b/src/ui/implementations_panel.py
@@ -7,12 +7,12 @@ class AF_UL_ImplementationsItems(bpy.types.UIList):
 	"""Class for drawing the list of implementations."""
 
 	def draw_item(self, context, layout: bpy.types.UILayout, data, item: AF_PR_Implementation, icon, active_data, active_propname, index):
-
+		prefix = "STRIP" if bpy.app.version >= (4, 4, 0) else "SEQUENCE"
 		# Add colored icon to quickly indicate if an implementation is readable
 		if item.is_valid:
-			icon = "SEQUENCE_COLOR_04"
+			icon = prefix + "_COLOR_04"
 		else:
-			icon = "SEQUENCE_COLOR_01"
+			icon = prefix + "_COLOR_01"
 
 		# Render the name of the implementation
 		row = layout.row()


### PR DESCRIPTION
Blender 4.4 changed the name of sequences to strips in the API, so enum values like this must be changed as well. To handle past versions, we set a prefix variable whose value is either `SEQUENCE` or `STRIP` depending on the verison.